### PR TITLE
Update k8s-job.yaml

### DIFF
--- a/practice-labs/Kubernetes/k8s-job.yaml
+++ b/practice-labs/Kubernetes/k8s-job.yaml
@@ -26,7 +26,7 @@ spec:
             - --max-cores 
             - "8"
             - --tmp-outdir-prefix 
-            - /calrissian/tmp 
+            - /calrissian/tmp/ 
             - --outdir
             - /calrissian/results
             - --usage-report 


### PR DESCRIPTION
fixes the --tmp-outdir-prefix